### PR TITLE
Changed Backdrop logic to allow compatibility with Shadowlands

### DIFF
--- a/Modules/FrameCombatDisplay.xml
+++ b/Modules/FrameCombatDisplay.xml
@@ -478,15 +478,13 @@
 			</OnDragStop>			
 		</Scripts>
 		<Frames>
-			<Frame parentKey="EnemyActive" frameLevel="6">
+			<Frame parentKey="EnemyActive" frameLevel="6" inherits="BackdropTemplate">
 				<Size>
 					<AbsDimension x="26" />
 				</Size>
-				<Backdrop edgeFile="Interface\Tooltips\UI-Tooltip-Border">
-					<EdgeSize>
-						<AbsValue val="14" />
-					</EdgeSize>
-				</Backdrop>
+				<KeyValues>
+					<KeyValue key="backdropInfo" value="BACKDROP_TOOLTIP_8_8_1111" type="global" />
+				</KeyValues>
 				<Scripts>
 					<OnLoad>
 						self:Raise(); -- makes it overlay the parent and all other frames


### PR DESCRIPTION
In Shadowlands, backdrops can no longer be defined in this way.
This patch makes the necessary changes for the addon to work with 9.0.1

This fixes bug #10 